### PR TITLE
fix: error message on signing transaction

### DIFF
--- a/src/WombatUser.ts
+++ b/src/WombatUser.ts
@@ -46,7 +46,7 @@ export class WombatUser extends User {
       return this.returnEosjsTransaction(broadcast, completedTransaction)
     } catch (e) {
       throw new UALWombatError(
-        'Unable to sign the given transaction',
+        e.message || 'Unable to sign the given transaction',
         UALErrorType.Signing,
         e)
     }


### PR DESCRIPTION
Error message with sign transaction

## Change Description

The signTransaction function currently is not providing the right error message. "unable to sign the transaction" (default value) is shown every time the transaction fails, which causes confusion about want went wrong. As per my changes, it is providing the error message, and if it is not found, then the default message.